### PR TITLE
Ignore GEK service NEG annotations

### DIFF
--- a/redis.tf
+++ b/redis.tf
@@ -1,5 +1,6 @@
 resource kubernetes_service redis {
   count = var.ignore ? 0 : 1
+
   metadata {
     name      = local.fullname
     namespace = var.namespace
@@ -8,6 +9,11 @@ resource kubernetes_service redis {
       "cloud.google.com/neg-status" = ""                             # Eliminates Terraform diff
       "cloud.google.com/neg"        = jsonencode({ ingress = true }) # Eliminates Terraform diff
     } : {}
+
+    labels = {
+      "app.kubernetes.io/name"    = local.fullname
+      "app.kubernetes.io/part-of" = "redis"
+    }
   }
 
   spec {
@@ -33,6 +39,7 @@ resource kubernetes_service redis {
 
 resource kubernetes_deployment redis {
   count = var.ignore ? 0 : 1
+
   metadata {
     name      = local.fullname
     namespace = var.namespace

--- a/redis.tf
+++ b/redis.tf
@@ -3,6 +3,11 @@ resource kubernetes_service redis {
   metadata {
     name      = local.fullname
     namespace = var.namespace
+
+    annotations = var.gke_neg ? {
+      "cloud.google.com/neg-status" = ""                             # Eliminates Terraform diff
+      "cloud.google.com/neg"        = jsonencode({ ingress = true }) # Eliminates Terraform diff
+    } : {}
   }
 
   spec {
@@ -17,6 +22,12 @@ resource kubernetes_service redis {
       name        = "redis"
       target_port = 6379
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata.0.annotations["cloud.google.com/neg-status"]
+    ]
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -56,3 +56,11 @@ variable resource_requests {
 variable instance_invocation_args {
   default = []
 }
+
+variable gke_neg {
+  description =<<EOF
+Handle GKE NEG auto annotations.
+https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing
+EOF
+  default = false
+}


### PR DESCRIPTION
As was discussed in a side channel, eliminates the Terraform diff. Similar to essjayhch/terraform-kubernetes-memcache#2.